### PR TITLE
Pin the version of the base image for cve_search

### DIFF
--- a/docker/images/cve_search/dockerfile-cve_search
+++ b/docker/images/cve_search/dockerfile-cve_search
@@ -1,5 +1,5 @@
-# Use the latest Python image
-FROM python:latest
+# Use specific Python image that does not change over time
+FROM python:3.10.6-bullseye
 
 # Set an environment variable with the directory
 # where we'll be running the app


### PR DESCRIPTION
The "latest" tag in any docker image can make the build fail when the image is updated.
Right now, the build for cve_search image fails because an unmet dependecy when installing `gevent`.

You can test it with this poc:
1. Save this file as `Dockerfile_gevent`
```Dockerfile
FROM python:latest

# this line - https://github.com/cve-search/cve-search/blob/master/requirements.txt#L11
RUN pip install gevent==21.12.0
```
2. Build by pulling any new base images
```sh
docker build --pull -f Dockerfile_gevent
# or
docker rmi python:latest
docker build -f Dockerfile_gevent
```
3. The following error occurs
```
...
      In file included from src/gevent/_greenlet_primitives.c:1050:
      /tmp/pip-install-e83lzpbm/gevent_2376e9681cbc4d41824ca616ce475b19/deps/greenlet/greenlet.h:42:5: error: unknown type name ‘CFrame’
         42 |     CFrame* cframe;
            |     ^~~~~~
      error: command '/usr/bin/gcc' failed with exit code 1
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
  ERROR: Failed building wheel for gevent
...
```


In order to fix this, I've used a image that I know it works (because I used it to build cve_search in the past)
```Dockerfile
FROM python:3.10.6-bullseye

# this line - https://github.com/cve-search/cve-search/blob/master/requirements.txt#L11
RUN pip install gevent==21.12.0
```