### PR TITLE
Remove .git directory from docker context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -143,3 +143,4 @@ cython_debug/
 .gitignore
 .dockerignore
 /.cve_search_data/
+.git/


### PR DESCRIPTION
Remove .git directory from docker context because is large and not used during build. Improves build time.

Also, storing the mongo db files in repo might not be a good long-term solution because with each change the repo size will increase again considerably.
The size of the repo right now is 2.6G and only ~300M are needed for build. The rest is git history.
```
/tmp/tmp.97O57ElvR2/CVE-Search-Docker master ❯ du -sh .
2,6G	.
/tmp/tmp.97O57ElvR2/CVE-Search-Docker master ❯ du -sh .git
2,3G	.git
```

Maybe Git LFS can solve this issue :thinking: 