### PR TITLE
fix file paths for SSL cert & key in configuration file

### DIFF
--- a/docker/files/cve_search/configuration.ini
+++ b/docker/files/cve_search/configuration.ini
@@ -26,8 +26,8 @@ Debug: False
 PageLength: 50
 LoginRequired: False
 SSL: True
-Certificate: etc/certificate.crt
-Key: etc/certificate.key
+Certificate: ./certificate.crt
+Key: ./certificate.key
 WebInterface: Full
 
 [Logging]


### PR DESCRIPTION
I made this change because the file path for the certificate files was incorrectly written in the configuration file. The configuration file is already copied to /app/etc in line 29 of the "images/cve_search/dockerfile-cve_search" file. So the configuration and certificate are in the same folder. 
